### PR TITLE
Fix up to work with new reactive syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -vr t/
+  - prove -e 'perl6 -Ilib' -vr t/
 sudo: false

--- a/t/client-server.t
+++ b/t/client-server.t
@@ -50,7 +50,6 @@ WebSocket::Client.connect(
         note 'got binary data'
     },
     on-close => -> $h {
-        note 'on close';
         ok 1, 'c: close';
     },
     on-ready => -> $h {
@@ -58,4 +57,5 @@ WebSocket::Client.connect(
         $h.send-text("STEP1");
     },
 );
+
 


### PR DESCRIPTION
I think this has been broken since early January.

Giving the block for the supply a signature causes it to be the wrong sort of thing, and causes the tap that HTTP::Server::Tiny creates implicitly to get the Channel to fail because it trys to get the 'phasers' for the block.  The supply object isn't needed in the block anyway as a standalone 'done' works perfectly well.

Also within the supply { } block  'whenever' should be used rather than explicitly tapping the $sock.Supply as the supply block expects that.

All the tests pass but may be a little flaky because of the async-ness.
