### PR TITLE
Fix up client-server.t failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /src/Makefile
 /.panda-work
 /lib/.precomp/
+/t/lib/.precomp/

--- a/t/client-server.t
+++ b/t/client-server.t
@@ -14,7 +14,7 @@ plan 5;
 my $port = 15555;
 
 # server thread
-Thread.start({
+Promise.start: {
     note 'starting server';
     my $s = HTTP::Server::Tiny.new(port => $port);
     $s.run(-> %env {
@@ -33,8 +33,8 @@ Thread.start({
                 ok 1, 's: close';
             },
         );
-    });
-}, :app_lifetime);
+    })
+}
 
 wait_port($port);
 
@@ -56,6 +56,9 @@ await Promise.anyof(
         },
         on-ready => -> $h {
             ok 1, 'c: ready';
+            # Wait before sending the message to ensure the server handle setup is complete
+            # This behaviour seems to be related to HTTP::Server::Tiny
+            sleep 0.1;
             $h.send-text("STEP1");
         },
     )

--- a/t/client-server.t
+++ b/t/client-server.t
@@ -40,22 +40,25 @@ wait_port($port);
 
 note 'ready connect';
 
-WebSocket::Client.connect(
-    "ws://127.0.0.1:$port/",
-    on-text => -> $h, $txt {
-        is $txt, 'STEP2', 'c:text';
-        $h.send-close;
-    },
-    on-binary => -> $h, $txt {
-        note 'got binary data'
-    },
-    on-close => -> $h {
-        ok 1, 'c: close';
-    },
-    on-ready => -> $h {
-        ok 1, 'c: ready';
-        $h.send-text("STEP1");
-    },
+await Promise.anyof(
+  Promise.start({
+    WebSocket::Client.connect(
+        "ws://127.0.0.1:$port/",
+        on-text => -> $h, $txt {
+            is $txt, 'STEP2', 'c:text';
+            $h.send-close;
+        },
+        on-binary => -> $h, $txt {
+            note 'got binary data'
+        },
+        on-close => -> $h {
+            ok 1, 'c: close';
+        },
+        on-ready => -> $h {
+            ok 1, 'c: ready';
+            $h.send-text("STEP1");
+        },
+    )
+  }),
+  Promise.in(5).then( { fail "Test timed out!" } ),
 );
-
-

--- a/t/lib/Test/TCP.pm
+++ b/t/lib/Test/TCP.pm
@@ -1,21 +1,19 @@
 use v6;
 unit class Test::TCP;
 
-sub wait_port(int $port, Str $host='127.0.0.1', :$sleep=0.1, int :$times=100) is export {
+sub wait_port(Int $port, Str $host='127.0.0.1', Numeric(Cool) :$sleep = 0.1, Int :$times=100) is export {
     LOOP: for 1..$times {
         try {
             my $sock = IO::Socket::INET.new(host => $host, port => $port);
             $sock.close;
 
-            CATCH { default {
+            CATCH {
                 sleep $sleep;
                 next LOOP;
-            } }
+            }
         }
         return;
     }
 
     die "$host:$port doesn't open in {$sleep*$times} sec.";
 }
-
-


### PR DESCRIPTION
client-server.t has been causing issues such as #8 and recently on Rakudo version 2017.04.3-172-gf2af3db built on MoarVM version 2017.04-56-g8ad18b8 I've been encountering permanent hanging when running tests.

I've added a time out mechanism to the client to prevent the test hanging in the future.

The failure appears to be that the send-text method in the client's on-ready call back is triggered before the server is entirely ready. Since the server isn't ready the message gets lost and so the event sequence of the tests is broken, causing the observed hanging of the test.

I've added a short sleep before calling send-text. This solves the immediate issue.
In poking around in the WebSocket::P6SGI.pm I think there are some minor improvements that could be made, however I believe the primary issue may be with HTTP::Server::Tiny.