### PR TITLE
open /dev/urandom with :bin

### DIFF
--- a/lib/WebSocket/SecureRandom.pm6
+++ b/lib/WebSocket/SecureRandom.pm6
@@ -6,7 +6,7 @@ unit class WebSocket::SecureRandom;
 has $.fh;
 
 method new() {
-    my $fh = open '/dev/urandom', :r;
+    my $fh = open '/dev/urandom', :r, :bin;
     self.bless(fh => $fh);
 }
 


### PR DESCRIPTION
Recent rakudo needs `:bin` flag to open a binary file.
```
❯ perl6 -v
This is Rakudo version 2017.05-320-g8ec181019 built on MoarVM version 2017.05-25-g62bc54e9
implementing Perl 6.c.

❯ perl6 -e 'my $fh = open "/dev/urandom", :r; say $fh.read(16)'
Buf[uint8]:0x<>

❯ perl6 -e 'my $fh = open "/dev/urandom", :r, :bin; say $fh.read(16)'
Buf[uint8]:0x<e9 c8 9d 6d b1 c5 a8 1f 28 33 fc 64 93 c3 b9 ba>
```