### PR TITLE
Do not attempt to use chat subprotocol for clients

### DIFF
--- a/lib/WebSocket/Client.pm6
+++ b/lib/WebSocket/Client.pm6
@@ -75,10 +75,9 @@ method connect(
         "Upgrade: websocket",
         "Connection: Upgrade",
         "Sec-WebSocket-Key: $key",
-        "Sec-WebSocket-Protocol: chat",
         "Sec-WebSocket-Version: 13",
         "",
-        ''
+        ""
     ].join("\x0d\x0a");
     debug "writing request" if DEBUG;
     $socket.write($res.encode('latin1'));


### PR DESCRIPTION
Including a Sec-WebSocket-Protocol header is optional according to
RFC-6455. Since this library doesn't appear to support subprotocols at
the moment, connecting to a server that supports a subprotocol called
chat could cause errors in receiving/sending messages.